### PR TITLE
Fixes #14

### DIFF
--- a/addon/components/filter-content/component.js
+++ b/addon/components/filter-content/component.js
@@ -125,7 +125,7 @@ export default Ember.Component.extend ({
     try {
 
       // Ember.run.cancel (this.get ('debounceFilter'));
-      this.set ('debounceFilter', Ember.run.debounce (this, this.applyFilter, Number.parseInt (this.get ('timeout'), 10), false));
+      this.set ('debounceFilter', Ember.run.debounce (this, this.applyFilter, parseInt (this.get ('timeout'), 10), false));
 
     } catch (exception) {
 


### PR DESCRIPTION
Removed Number.parseInt() method in favor of the parseInt function to
prevent issues in Internet Explorer browsers
